### PR TITLE
Harvester support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ckan"]
 	path = ckan
 	url = https://github.com/ckan/ckan.git
+[submodule "ckanext-harvest"]
+	path = ckanext-harvest
+	url = https://github.com/ckan/ckanext-harvest.git

--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ cd communitydata.io/
 datacats init
 ```
 
+### Setting up the Harvester
+Point the `ckan.harvest.mq.hostname` variable in the .ini to a redis instance,
+which will act as a job queue. Then to run jobs, run the commands in the
+harvester [docs](https://github.com/ckan/ckanext-harvest#running-the-harvest-jobs)
+
+Note - if you are using datacats, you can run these commands easily like so:
+```
+cd community/ckanext-harvest/
+datacats paster harvester gather_consumer
+datacats paster harvester fetch_consumer
+datacats paster harvester run
+```
+
+You will of course still need to set up
+[harvest sources](communityopendatacatalogs.csv) on the ckan harvest admin
+interface at `/harvest`.
+
 ## Deployment
 If you are a committer and want deploy privileges, talk to
 [@mheadd](http://github.com/mheadd).

--- a/development.ini
+++ b/development.ini
@@ -96,7 +96,10 @@ solr_url = http://solr:8080/solr
 #       Add ``datapusher`` to enable DataPusher
 #		Add ``resource_proxy`` to enable resorce proxying and get around the
 #		same origin policy
-ckan.plugins = datastore resource_proxy text_view recline_grid_view recline_graph_view community_theme
+ckan.plugins = datastore resource_proxy text_view recline_grid_view recline_graph_view community_theme harvest ckan_harvester
+
+ckan.harvest.mq.type = redis
+#ckan.harvest.mq.hostname = boot2docker
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)


### PR DESCRIPTION
There is a harvester now running on communitydata.io

The site is already harvesting all the CKAN-based sites in the catalogs file, as those were easy to set up. It mostly works nicely - the harvester has a couple of unresolved issues with ckan 2.3

Closes #2 